### PR TITLE
Update to logfile-open: change filemode to 0664

### DIFF
--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -72,7 +72,7 @@ static inline int log_push(struct log_message *msg, struct flb_log *log)
         return write(STDERR_FILENO, msg->msg, msg->size);
     }
     else if (log->type == FLB_LOG_FILE) {
-        fd = open(log->out, O_CREAT | O_WRONLY | O_APPEND, 0666);
+        fd = open(log->out, O_CREAT | O_WRONLY | O_APPEND, 0664);
         if (fd == -1) {
             fprintf(stderr, "[log] error opening log file %s. Using stderr.\n",
                     log->out);


### PR DESCRIPTION
Configuring fluent-bit in environments that enforce certain security baselines (such as CIS, STIG, NIST) the file-mode "world-writeable" is highly undesirable. To remove "write" from the "other-part" file-mask when opening/creating a log-file is enough to calm down compliance checks. It does not to have a negative impact to other users of the system to read the log-file.

<!-- Provide summary of changes -->
The filemode when creating a file has been changed from 0666 to 0664. No other code was changed.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/R ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
